### PR TITLE
Recover broken backlinks flagged by Ahrefs

### DIFF
--- a/accounting-top-100.html
+++ b/accounting-top-100.html
@@ -7,6 +7,8 @@ permalink: /accounting-top-100/
 redirect_from:
   - /accounting-top-100/r/2684345/1/
   - /accounting-top-100/p/6198510/r/2603907/
+  - /accounting-top-100/r/2654032/5/
+  - /players/join/16877/
 ---
 
 <style>

--- a/blockchain-100.html
+++ b/blockchain-100.html
@@ -4,6 +4,9 @@ title: "The 100 Most Influential Blockchain Companies (2018) — Archive"
 description: "Archive of the Blockchain 100 leaderboard published by Richtopia on rise.global, ranking the 100 most influential blockchain companies for the week ending 9 May 2018. Powered by Klout and Twitter signals."
 keywords: "blockchain 100, top blockchain companies, most influential blockchain companies, blockchain leaderboard, blockchain influencer ranking"
 permalink: /blockchain-100/
+redirect_from:
+  - /blockchain-100/r/2639637/1/
+  - /best-in-blockchain-cryptocurrency/r/latest/
 ---
 
 <style>

--- a/redirects/arcade-challenges-s1r3.html
+++ b/redirects/arcade-challenges-s1r3.html
@@ -1,0 +1,4 @@
+---
+permalink: /arcade-challenges-leaderboard-season-1-round-3/
+redirect_to: /
+---

--- a/redirects/city-championships-la.html
+++ b/redirects/city-championships-la.html
@@ -1,0 +1,4 @@
+---
+permalink: /city-championships-season-3-los-angeles/
+redirect_to: /
+---

--- a/redirects/cybersecurity-power-100.html
+++ b/redirects/cybersecurity-power-100.html
@@ -1,0 +1,4 @@
+---
+permalink: /display/the-cybersecurity-power-100/
+redirect_to: /
+---

--- a/redirects/ds-sm-marketing-power-100.html
+++ b/redirects/ds-sm-marketing-power-100.html
@@ -1,0 +1,4 @@
+---
+permalink: /the-ds-sm-and-marketing-infl-power-100/
+redirect_to: /
+---

--- a/redirects/gurus-deep.html
+++ b/redirects/gurus-deep.html
@@ -1,0 +1,4 @@
+---
+permalink: /gurus/p/1966550/r/2621954/
+redirect_to: /
+---

--- a/redirects/gurus-r.html
+++ b/redirects/gurus-r.html
@@ -1,0 +1,4 @@
+---
+permalink: /gurus/r/2555721/
+redirect_to: /
+---

--- a/redirects/instech.html
+++ b/redirects/instech.html
@@ -1,0 +1,4 @@
+---
+permalink: /instech/
+redirect_to: /
+---

--- a/redirects/ld-influencer-list.html
+++ b/redirects/ld-influencer-list.html
@@ -1,0 +1,4 @@
+---
+permalink: /the-ld-influencer-list-power-100/
+redirect_to: /
+---

--- a/redirects/leaderboard-hcsm.html
+++ b/redirects/leaderboard-hcsm.html
@@ -1,0 +1,4 @@
+---
+permalink: /leaderboard/board/hcsm/
+redirect_to: /
+---

--- a/redirects/lgbt-cityexecs-powerlist.html
+++ b/redirects/lgbt-cityexecs-powerlist.html
@@ -1,0 +1,4 @@
+---
+permalink: /lgbt-cityexecs-powerlist/r/2476166/
+redirect_to: /
+---

--- a/redirects/power100landing.html
+++ b/redirects/power100landing.html
@@ -1,0 +1,4 @@
+---
+permalink: /pages/power100landing/
+redirect_to: /
+---

--- a/redirects/shareable-cities.html
+++ b/redirects/shareable-cities.html
@@ -1,0 +1,4 @@
+---
+permalink: /shareable-cities/
+redirect_to: /
+---

--- a/redirects/top-berkshire-estate-agents.html
+++ b/redirects/top-berkshire-estate-agents.html
@@ -1,0 +1,4 @@
+---
+permalink: /top-berkshire-estate-agents/
+redirect_to: /
+---

--- a/redirects/top-women-leaders.html
+++ b/redirects/top-women-leaders.html
@@ -1,0 +1,4 @@
+---
+permalink: /top-women-leaders/
+redirect_to: /
+---

--- a/redirects/young-entrepreneurs.html
+++ b/redirects/young-entrepreneurs.html
@@ -1,0 +1,4 @@
+---
+permalink: /young-entrepreneurs/p/5812195/r/2502354/
+redirect_to: /
+---

--- a/top-fintech-people.html
+++ b/top-fintech-people.html
@@ -7,6 +7,9 @@ permalink: /top-fintech-people/
 redirect_from:
   - /top-fintech-people/r/latest/
   - /top-fintech-people/p/2246701/r/2571685/
+  - /top-fintech-people/hof/
+  - /top-fintech-people/p/1190471/r/2571685/
+  - /top-fintech-people/p/5827363/r/2460461/
 ---
 
 <style>


### PR DESCRIPTION
## Summary
- Added 15 new redirect stubs in `/redirects/` for lost list/leaderboard URLs with quality referrers (Supercell, Scoop.it, Wikipedia P2P Foundation, NintendoLife, businessabc, Thinkers360, TrainingZone, fortuneherald, eldestapeweb, clarity.fm and others), all 301 → `/`.
- Extended `redirect_from:` on the existing archive pages: `accounting-top-100.html` (incl. `/players/join/16877/` from CPA Practice Advisor → archive), `blockchain-100.html` (incl. `/best-in-blockchain-cryptocurrency/r/latest/` from Forbes + decrypt.co), and `top-fintech-people.html` (incl. `/hof/` and deep player paths).
- `/player/{id}/...` URLs are intentionally left as 404 — referrers there are overwhelmingly spam (escort listings, paste sites, scraped forums); 404 lets Google drop them naturally instead of passing weak signal to homepage.

## Test plan
- [ ] GitHub Actions Jekyll build passes
- [ ] Spot-check 2-3 redirects post-deploy (e.g. `/best-in-blockchain-cryptocurrency/r/latest/` → `/blockchain-100/`, `/players/join/16877/` → `/accounting-top-100/`, `/instech/` → `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)